### PR TITLE
Use isgeneratorfunction to find yielding fixtures

### DIFF
--- a/owntest/__main__.py
+++ b/owntest/__main__.py
@@ -1,0 +1,3 @@
+from . import test_runner
+
+test_runner()


### PR DESCRIPTION
The `inspect` package provides a helper to detect a function that uses `yield`.
Using this we can avoid consuming one step from the case when a fixture actually wants to return a generator/iterator.

However, `isgeneratorfunction` wouldn't work because `owntest.fixture` was returning a wrapper function.
I changed this to a natural "registry" pattern, where the decorator adds the function to the registry, and returns the decorated item unchanged.

To make this work I had to move everything into a package;
Without doing this, Python will import `owntest` twice, because it doesn't see it as imported when called by `python -m`.

Finally, I made sure that once a test was finished, we consumed each of the generator fixtures again to ensure they cleaned up.
